### PR TITLE
Added API's test cases for Shareable Connectors and Shareable Data Models

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -695,6 +695,15 @@ module.exports = defineConfig({
     deleteUserTypes1: "/api/v2/",
     deleteUserTypes2: "user_types/",
     deleteUserTypes3: "/",
+    getShareableConnectors: "/api/v2/shareable-components/",
+    addShareableConnectors: "/api/v2/shareable-components/",
+    getShareableConnectorsById1: "/api/v2/",
+    getShareableConnectorsById2: "shareable-components/",
+    getShareableConnectorsById3: "/",
+    getShareableDataModels: "/api/v2/shareable-data-models/",
+    getShareableDataModelsByID1: "/api/v2/",
+    getShareableDataModelsByID2: "shareable-data-models/",
+    getShareableDataModelsByID3: "/",
 
     // ---------------PRD New FLow----------------------//
     getOrganizationPRDList: "/api/v1/prd/",

--- a/cypress/integration/api/pages/ConnectorsPage.js
+++ b/cypress/integration/api/pages/ConnectorsPage.js
@@ -137,3 +137,67 @@ export const getConnectorscategories = (auth_key) => {
         return response;
     })
 };
+
+export const doGetShareableConnectors = (auth_key) => {
+    return cy.request({
+        method: 'GET',
+        url: Cypress.env('baseUrl') + Cypress.env('getShareableConnectors'),
+        headers: {
+            'Authorization': 'Token ' + auth_key
+        }
+    }).then((response) => {
+        return response;
+    })
+}
+
+export const doCreateShareableConnectors = (auth_key) => {
+    return cy.fixture('api_addShareableConnectors.json').then((myFixture) => {
+        cy.request({
+            method: 'POST',
+            url: Cypress.env('baseUrl') + Cypress.env('addShareableConnectors'),
+            headers: {
+                'Authorization': 'Token ' + auth_key
+            },
+            body: myFixture
+        }).then((response) => {
+            return response;
+        })
+    })
+}
+
+export const doGetShareableConnectorsByID = (auth_key, shareableconnectors_id) => {
+    return cy.request({
+        method: 'GET',
+        url: Cypress.env('baseUrl') + Cypress.env('getShareableConnectorsById1')+Cypress.env('getShareableConnectorsById2')+shareableconnectors_id+Cypress.env('getShareableConnectorsById3'),
+        headers: {
+            'Authorization': 'Token ' + auth_key
+        }
+    }).then((response) => {
+        return response;
+    })
+}
+
+
+export const doGetShareableDataModels = (auth_key) => {
+    return cy.request({
+        method: 'GET',
+        url: Cypress.env('baseUrl') + Cypress.env('getShareableDataModels'),
+        headers: {
+            'Authorization': 'Token ' + auth_key
+        }
+    }).then((response) => {
+        return response;
+    })
+}
+
+export const doGetShareableDataModelsByID = (auth_key, shareabledatamodels_id) => {
+    return cy.request({
+        method: 'GET',
+        url: Cypress.env('baseUrl') + Cypress.env('getShareableDataModelsByID1')+Cypress.env('getShareableDataModelsByID2')+shareabledatamodels_id+Cypress.env('getShareableDataModelsByID3'),
+        headers: {
+            'Authorization': 'Token ' + auth_key
+        }
+    }).then((response) => {
+        return response;
+    })
+}

--- a/cypress/integration/api/tests/ConnectorsPageTest.js
+++ b/cypress/integration/api/tests/ConnectorsPageTest.js
@@ -1,7 +1,7 @@
 /// <reference types = "cypress"/>
 import { doCteareApp } from '../pages/DashboardPage.js';
 import { doConnectorLogin } from '../pages/loginPage.js';
-import { doCreateConnector, doGetConnector, doGetInstallerInstalComponent, doGetConnectorUsingId, doUpdateConnector, doEditConnector, doDeleteConnector, getConnectors, getConnectorscategories } from '../pages/ConnectorsPage.js';
+import { doCreateConnector, doGetConnector, doGetInstallerInstalComponent, doGetConnectorUsingId, doUpdateConnector, doEditConnector, doDeleteConnector, getConnectors, getConnectorscategories,doGetShareableConnectors, doCreateShareableConnectors, doGetShareableConnectorsByID, doGetShareableDataModels, doGetShareableDataModelsByID } from '../pages/ConnectorsPage.js';
 
 let authKey;
 let app_id;
@@ -9,6 +9,8 @@ let app_name;
 let connector_name;
 let connector_description;
 let connector_id;
+let shareableconnectors_id;
+let shareabledatamodels_id;
 
 describe("Connectors Page", () => {
     app_name = 'TestAPIAutoSettings' + (Math.random() + 1).toString(36).substring(7);
@@ -95,6 +97,42 @@ describe("Connectors Page", () => {
             expect(response.status).to.eq(200)
         })
     })
+
+    it('Get Shareable Connectors Flow', () => {
+        doGetShareableConnectors(authKey).then((response) => {
+            cy.log("Get Connectors response", response.body)
+            expect(response.status).to.eq(200)
+        })
+    })
+
+    it('Add Shareable Connectors Flow', () => {
+        doCreateShareableConnectors(authKey).then((response) => {
+            expect(response.status).to.eq(201)
+            shareableconnectors_id = response.body.id;
+            cy.log("AddShareable Connectors", response.body)
+        })
+    })
+
+    it('Get Shareable Connectors Flow', () => {
+        doGetShareableConnectorsByID(authKey, shareableconnectors_id).then((response) => {
+            expect(response.status).to.eq(200)
+            cy.log("Get Code Components Using Id response", response.body)
+        })
+    })
     
+    it('Get Shareable Data Models Flow', () => {
+        doGetShareableDataModels(authKey).then((response) => {
+            cy.log("Get Shareable Data Models response", response.body)
+            shareabledatamodels_id = response.body.results[0].id;
+            expect(response.status).to.eq(200)
+        })
+    })
+
+    it('Get Shareable Data Models Flow By ID', () => {
+        doGetShareableDataModelsByID(authKey, shareabledatamodels_id).then((response) => {
+            expect(response.status).to.eq(200)
+            cy.log("Get Shareable Data Models Id response", response.body)
+        })
+    })
 
 })


### PR DESCRIPTION
Automated 5 API's Test cases - 
1. GET - /api/v2/shareable-components/
2. POST - /api/v2/shareable-components/
3. GET ID  - /api/v2/shareable-components/
4. GET - /api/v2/shareable-data-models/
5. GET ID - /api/v2/shareable-data-models/