### PR TITLE
Added API's test cases for Addons & TOTP device, Scaffolds, Socialaccounts

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -751,6 +751,14 @@ module.exports = defineConfig({
     getModels: "/api/v2/models/",
     getModelsByID1: "/api/v2/models/",
     getModelsByID2: "/",
+    getAddons: "/api/v2/addons/",
+    getaddonsByID1: "/api/v2/addons/",
+    getaddonsByID2: "/",
+    getScaffolds: "/api/v1/scaffolds/",
+    getTotpdevice: "/api/v2/totp/device/",
+    getSocialaccounts: "/api/v2/socialaccounts/",
+    getSettingsfe: "/api/v2/settings/fe/",
+
 
     // ---------------PRD New FLow----------------------//
     getOrganizationPRDList: "/api/v1/prd/",

--- a/cypress/integration/api/pages/DashboardPage.js
+++ b/cypress/integration/api/pages/DashboardPage.js
@@ -1027,6 +1027,87 @@ export const doPostcbusers = (auth_key) => {
         })
     }
 
+    export const doGetAddons = (auth_key) => {
+        return cy.request({
+            method: 'GET',
+            url: Cypress.env('baseUrl') + Cypress.env('getAddons'),
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                'Authorization': 'Token ' + auth_key,
+            },
+        }).then((response) => {
+            return response;
+        })
+    };
 
+    export const doGetAddonsByID = (auth_key, addons_id) => {
+        return cy.request({
+            method: 'GET',
+            url: Cypress.env('baseUrl') + Cypress.env('getaddonsByID1')+addons_id+Cypress.env('getaddonsByID2'),
+            headers: {
+                'Authorization': 'Token ' + auth_key
+            }
+        }).then((response) => {
+            return response;
+        })
 
+    };
+
+    export const doGetScaffolds = (auth_key) => {
+        return cy.request({
+            method: 'GET',
+            url: Cypress.env('baseUrl') + Cypress.env('getScaffolds'),
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                'Authorization': 'Token ' + auth_key,
+            },
+        }).then((response) => {
+            return response;
+        })
+    };
+
+    export const doTOTPdevice = (auth_key) => {
+        return cy.request({
+            method: 'GET',
+            url: Cypress.env('baseUrl') + Cypress.env('getTotpdevice'),
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                'Authorization': 'Token ' + auth_key,
+            },
+        }).then((response) => {
+            return response;
+        })
+    };
+
+    export const doGetSocialaccounts = (auth_key) => {
+        return cy.request({
+            method: 'GET',
+            url: Cypress.env('baseUrl') + Cypress.env('getSocialaccounts'),
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                'Authorization': 'Token ' + auth_key,
+            },
+        }).then((response) => {
+            return response;
+        })
+    };
+
+    
+    export const doGetSettingsfe = (auth_key) => {
+        return cy.request({
+            method: 'GET',
+            url: Cypress.env('baseUrl') + Cypress.env('getSettingsfe'),
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                'Authorization': 'Token ' + auth_key,
+            },
+        }).then((response) => {
+            return response;
+        })
+    };
     

--- a/cypress/integration/api/tests/dashboardtest.js
+++ b/cypress/integration/api/tests/dashboardtest.js
@@ -1,6 +1,6 @@
 // import LoginPage from '../pages/loginPage';
 /// <reference types = "cypress"/>
-import { doDeleteCertificationsid,doPatchCertificationsid,doputCertificationsid,dogetCertificationsid,doPostCertifications, dogetCertifications,doDeleteFile,doUpdateWithPatchFile,doUpdateWithPutFile,doGetFileById,doCreateFile,doDeleteComponent,doUpdateWithPatchComponent,doUpdateWithPutComponent,doGetComponentById,doCreateComponent,doGetComponentList,doDeleteBugTask,doUpdateWithPatchBugTask,doUpdateWithPutBugTask,doGetBugTaskById,doCreateBugTask,doGetBugTaskList,doGetAppetizeBuilds,getAppListById,dogGetFilesList,getEdges,getUserList,getAuditLogList,getAttributes,doCreateAttributes,getNotification, getAppSupportType, getCertificateList, doGetSkillsList, appTypeList, appTypeUsingId, doCteareApp, searchApp, doCheckAppGeneration, getInvoice, searchInvoice, getAppLogs, getAppLogsUsingLogID, getStatistics, getBuildstages, getCandidates, getFeedbacks, getFeedbacksCategories,getReports, doGetFeedbacksCategoriesByID,dogetcbusers,doPostcbusers,dogetcbusersbyId,doputcbusersbyId,dopatchcbusersbyId, doGetReportsByID,doGetDevloperrequest,doGetDevloperrequestByID, doGetResponses, doGetAppetizedevices, dogGetAPIspec, doGetAttributesById,doGetLogs,doGetLogsById, doPostDashboardfeedbacks, doGetMemberfeedback, doGetfeedbackmemberByID} from '../pages/DashboardPage.js';
+import { doDeleteCertificationsid,doPatchCertificationsid,doputCertificationsid,dogetCertificationsid,doPostCertifications, dogetCertifications,doDeleteFile,doUpdateWithPatchFile,doUpdateWithPutFile,doGetFileById,doCreateFile,doDeleteComponent,doUpdateWithPatchComponent,doUpdateWithPutComponent,doGetComponentById,doCreateComponent,doGetComponentList,doDeleteBugTask,doUpdateWithPatchBugTask,doUpdateWithPutBugTask,doGetBugTaskById,doCreateBugTask,doGetBugTaskList,doGetAppetizeBuilds,getAppListById,dogGetFilesList,getEdges,getUserList,getAuditLogList,getAttributes,doCreateAttributes,getNotification, getAppSupportType, getCertificateList, doGetSkillsList, appTypeList, appTypeUsingId, doCteareApp, searchApp, doCheckAppGeneration, getInvoice, searchInvoice, getAppLogs, getAppLogsUsingLogID, getStatistics, getBuildstages, getCandidates, getFeedbacks, getFeedbacksCategories,getReports, doGetFeedbacksCategoriesByID,dogetcbusers,doPostcbusers,dogetcbusersbyId,doputcbusersbyId,dopatchcbusersbyId, doGetReportsByID,doGetDevloperrequest,doGetDevloperrequestByID, doGetResponses, doGetAppetizedevices, dogGetAPIspec, doGetAttributesById,doGetLogs,doGetLogsById, doPostDashboardfeedbacks, doGetMemberfeedback, doGetfeedbackmemberByID, doGetAddons, doGetAddonsByID, doGetScaffolds, doTOTPdevice, doGetSocialaccounts, doGetSettingsfe} from '../pages/DashboardPage.js';
 import { doDashboardLogin } from '../pages/loginPage.js';
 
 let component_id;
@@ -20,6 +20,7 @@ let developerrequest_id;
 let attributes_id ;
 let logs_id;
 let memberfeedback_id;
+let addons_id;
 describe("Dashboard Page", () => {
     const app_name = 'TestAPIAutoSettings' + (Math.random() + 1).toString(36).substring(7);
     const username = 'cbrahul' + (Math.random() + 1).toString(36).substring(7);
@@ -532,5 +533,47 @@ describe("Dashboard Page", () => {
         })
     })
 
+    it('Get Addons Flow', () => {
+        doGetAddons(authKey).then((response) => {
+            cy.log("Get Addons response", response.body)
+            addons_id = response.body[0].id;
+            expect(response.status).to.eq(200)
+        })
+    })
+
+    it('Get Addons Flow By ID', () => {
+        doGetAddonsByID(authKey, addons_id).then((response) => {
+            expect(response.status).to.eq(200)
+            cy.log("Get Addons Id response", response.body)
+        })
+    })
+
+    it('Get Scaffolds Flow', () => {
+        doGetScaffolds(authKey).then((response) => {
+            cy.log("Get Scaffolds response", response.body)
+            expect(response.status).to.eq(200)
+        })
+    })
+
+    it('Get TOTP Device Flow', () => {
+        doTOTPdevice(authKey).then((response) => {
+            cy.log("Get ToTP Device response", response.body)
+            expect(response.status).to.eq(201)
+        })
+    })
+
+    it('Get Socialaccounts Flow', () => {
+        doGetSocialaccounts(authKey).then((response) => {
+            cy.log("Get Socialaccounts response", response.body)
+            expect(response.status).to.eq(200)
+        })
+    })
+
+    it('Get Settingsfe Flow', () => {
+        doGetSettingsfe(authKey).then((response) => {
+            cy.log("Get Settingsfe response", response.body)
+            expect(response.status).to.eq(200)
+        })
+    })
 
 })


### PR DESCRIPTION
Automated new 6 API's test cases - 
1. - /api/v2/addons/ (GET)
2. - /api/v2/addons/ (GET ID)
3. - /api/v1/scaffolds/ (GET)
4. - /api/v2/totp/device/ (GET)
5. - /api/v2/socialaccounts/ (GET)
6. - /api/v2/settings/fe/ (GET)

![pass1](https://github.com/anishcb/crowdbotics_automation/assets/95238842/dac39132-a83f-494b-9d68-53323760b9f3)
