### PR TITLE
Document functionality_apis

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -882,7 +882,21 @@ module.exports = defineConfig({
     deleteUserRolesByIdByoriganization1: "/api/v1/prd/",
     deleteUserRolesByIdByoriganization2: "/roles/",
     deleteUserRolesByIdByoriganization3: "/",
-    
+
+    createDocument1:"/api/v1/apps/",
+    createDocument2:"/document/",
+    getDocumentById1:"/api/v1/apps/",
+    getDocumentById2:"/document/",
+    getDocumentById3:"/",
+    putDocumentById1:"/api/v1/apps/",
+    putDocumentById2:"/document/",
+    putDocumentById3:"/",
+    patchDocumentById1:"/api/v1/apps/",
+    patchDocumentById2:"/document/",
+    patchDocumentById3:"/",
+    deleteDocumentById1:"/api/v1/apps/",
+    deleteDocumentById2:"/document/",
+    deleteDocumentById3:"/"
 
   },
   e2e: {

--- a/cypress/fixtures/api_create_document.json
+++ b/cypress/fixtures/api_create_document.json
@@ -1,0 +1,4 @@
+{
+    "title": "Document",
+    "description": "Generate a Business Requirements Document (BRD) from the uploaded PRD and business strategy documents. The BRD should outline the core business objectives, functional requirements, and expected outcomes of the product. Include key performance indicators (KPIs) that will measure success, and specify any dependencies or constraints that may impact the project. This document will be used for review by stakeholders to ensure alignment on business goals and project scope before development begins."
+}

--- a/cypress/fixtures/api_patchDocument.json
+++ b/cypress/fixtures/api_patchDocument.json
@@ -1,0 +1,4 @@
+{
+    "title": "Update patch Document",
+    "description": "Please create a Technical Specification Summary using the detailed technical PRD uploaded. The summary should outline the main architecture decisions, API integrations, and backend requirements. Additionally, please include a list of dependencies and any planned technology stack. This will be used by the engineering team to gain an overview before diving into development."
+}

--- a/cypress/fixtures/api_putDocument.json
+++ b/cypress/fixtures/api_putDocument.json
@@ -1,0 +1,4 @@
+{
+    "title": "Updated Document",
+    "description": "Please create a Technical Specification Summary using the detailed technical PRD uploaded. The summary should outline the main architecture decisions, API integrations, and backend requirements. Additionally, please include a list of dependencies and any planned technology stack. This will be used by the engineering team to gain an overview before diving into development."
+}

--- a/cypress/integration/api/pages/DocumentPage.js
+++ b/cypress/integration/api/pages/DocumentPage.js
@@ -1,0 +1,68 @@
+/// <reference types = "cypress"/>
+
+export const doCreateDocument = (auth_key,app_id) => {
+    return cy.fixture('api_create_document.json').then((myFixture) => {
+        cy.request({
+            method: 'POST',
+            url: Cypress.env('baseUrl') + Cypress.env('createDocument1')+app_id+Cypress.env('createDocument2'),
+            headers: {
+                'Authorization': 'Token ' + auth_key
+            },
+            body: myFixture
+        }).then((response) => {
+            return response;
+        })
+    })
+}
+export const doGetDocumentById = (auth_key,app_id,document_id) => {
+
+    return cy.request({
+        method: 'GET',
+        url: Cypress.env('baseUrl') + Cypress.env('getDocumentById1')+app_id+Cypress.env('getDocumentById2')+document_id+Cypress.env('getDocumentById3'),
+        headers: {
+            'Authorization': 'Token ' + auth_key
+        }
+    }).then((response) => {
+        return response;
+    })
+}
+export const doPutDocumentById = (auth_key,app_id,document_id) => {
+    return cy.fixture('api_putDocument.json').then((myFixture) => {
+        cy.request({
+            method: 'PUT',
+            url: Cypress.env('baseUrl') + Cypress.env('putDocumentById1')+app_id+Cypress.env('putDocumentById2')+document_id+Cypress.env('putDocumentById3'),
+            headers: {
+                'Authorization': 'Token ' + auth_key
+            },
+            body: myFixture
+        }).then((response) => {
+            return response;
+        })
+    })
+}
+export const doPatchDocumentById = (auth_key,app_id,document_id) => {
+    return cy.fixture('api_patchDocument.json').then((myFixture) => {
+        cy.request({
+            method: 'PATCH',
+            url: Cypress.env('baseUrl') + Cypress.env('patchDocumentById1')+app_id+Cypress.env('patchDocumentById2')+document_id+Cypress.env('patchDocumentById3'),
+            headers: {
+                'Authorization': 'Token ' + auth_key
+            },
+            body: myFixture
+        }).then((response) => {
+            return response;
+        })
+    })
+}
+export const doDeleteDocumentById = (auth_key,app_id,document_id) => {
+
+    return cy.request({
+        method: 'DELETE',
+        url: Cypress.env('baseUrl') + Cypress.env('deleteDocumentById1')+app_id+Cypress.env('deleteDocumentById2')+document_id+Cypress.env('deleteDocumentById3'),
+        headers: {
+            'Authorization': 'Token ' + auth_key
+        }
+    }).then((response) => {
+        return response;
+    })
+}

--- a/cypress/integration/api/tests/DocumentPageTest.js
+++ b/cypress/integration/api/tests/DocumentPageTest.js
@@ -1,0 +1,53 @@
+
+/// <reference types = "cypress"/>
+import { doCteareApp } from '../pages/DashboardPage.js';
+import { doCatalogLogin } from '../pages/loginPage.js';
+import { doCreateDocument,doGetDocumentById,doPutDocumentById,doPatchDocumentById,doDeleteDocumentById } from '../pages/DocumentPage.js';
+
+let document_id;
+let app_id;
+let app_name;
+let authKey;
+describe("Document Page", () => {
+    app_name = 'TestAPIAutoSettings' + (Math.random() + 1).toString(36).substring(7);
+    it('Create document flow', () => {
+        doCatalogLogin().then((response) => {
+            authKey = response.body.key;
+            doCteareApp(authKey, app_name).then((response) => {
+                cy.log("login response", response.body)
+                app_id = response.body.id;
+                app_name = response.body.name;
+                localStorage.setItem('app_id', response.body.id);
+                doCreateDocument(authKey,app_id).then((response) => {
+                   document_id = response.body.id;
+                    expect(response.status).to.eq(201)
+                    cy.log("Create document flow response", response.body)
+                })
+            })
+        })
+    })
+    it('Get document by id flow', () => {
+        doGetDocumentById(authKey, app_id,document_id).then((response) => {
+            expect(response.status).to.eq(200)
+            cy.log("Get document by id flow response", response.body)
+        })
+    })
+    it('Put document by id flow', () => {
+        doPutDocumentById(authKey, app_id,document_id).then((response) => {
+            expect(response.status).to.eq(200)
+            cy.log("Put document by id flow response", response.body)
+        })
+    })
+    it('Patch document by id flow', () => {
+        doPatchDocumentById(authKey, app_id,document_id).then((response) => {
+            expect(response.status).to.eq(200)
+            cy.log("Patch document by id flow response", response.body)
+        })
+    })
+    it('Delete document by id flow', () => {
+        doDeleteDocumentById(authKey, app_id,document_id).then((response) => {
+            expect(response.status).to.eq(204)
+            cy.log("Delete document by id flow response", response.body)
+        })
+    })
+})


### PR DESCRIPTION
Dear Team,

I have automated five new APIs related to document functionality. Kindly review my pull request (PR) and provide appropriate comments.

The following APIs have been automated with their respective HTTP methods:

POST /api/v1/apps/{app_apk}/document/ - Create a new document.
GET /api/v1/apps/{app_apk}/document/{id} - Retrieve a document by ID.
PUT /api/v1/apps/{app_apk}/document/{id} - Update a document by ID.
PATCH /api/v1/apps/{app_apk}/document/{id} - Partially update a document by ID.
DELETE /api/v1/apps/{app_apk}/document/{id} - Delete a document by ID.
I have also attached a screenshot as an artifact to demonstrate the functionality.
<img width="960" alt="image" src="https://github.com/user-attachments/assets/e063f4f6-2c35-47e1-af66-362c8bf67ff5">
