### PR TITLE
I have automated the Kenobi API using a public repository.

### DIFF
--- a/cypress/fixtures/api_Create_Kenobi_C2S_Public_Repo.json
+++ b/cypress/fixtures/api_Create_Kenobi_C2S_Public_Repo.json
@@ -1,0 +1,4 @@
+{
+  "public_repo_url": "https://github.com/TiwariMithilesh/knobitestpublic",
+  "app_custom_name": "kenobitest1234567"
+}

--- a/cypress/fixtures/api_Patch_Kenobi_C2S_Public_Repo.json
+++ b/cypress/fixtures/api_Patch_Kenobi_C2S_Public_Repo.json
@@ -1,0 +1,4 @@
+{
+  "public_repo_url": "https://github.com/TiwariMithilesh/knobitestpublic",
+  "app_custom_name": "kenobitest12345678"
+}

--- a/cypress/fixtures/api_Put_Kenobi_C2S_Public_Repo.json
+++ b/cypress/fixtures/api_Put_Kenobi_C2S_Public_Repo.json
@@ -1,0 +1,4 @@
+{
+  "public_repo_url": "https://github.com/TiwariMithilesh/knobitestpublic",
+  "app_custom_name": "kenobitest1234567"
+}

--- a/cypress/integration/api/pages/KenobiPage.js
+++ b/cypress/integration/api/pages/KenobiPage.js
@@ -76,5 +76,84 @@ export const doDeleteKenobiC2SUsingPrivateRepoById = (auth_key, kenobi_id) => {
     })
 };
 
+export const doCreateKenobiC2SUsingPubliceRepo = (auth_key) => {
+    return cy.fixture('api_Create_Kenobi_C2S_Public_Repo.json').then((myFixture) => {
+        cy.request({
+            method: 'POST',
+            url: Cypress.env('baseUrl') + Cypress.env('CreateKenobiC2S'),
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                'Authorization': 'Token ' + auth_key,
+            },
+            body: myFixture
+        }).then((response) => {
+            return response;
+        })
+    })
+};
+
+export const doGetKenobiC2SUsingPublicRepoById = (auth_key, kenobi_id) => {
+
+    return cy.request({
+        method: 'GET',
+        url: Cypress.env('baseUrl') + Cypress.env('CreateKenobiC2S') + kenobi_id + Cypress.env('CreateKenobiC2S1'),
+        headers: {
+            'Authorization': 'Token ' + auth_key
+        }
+    }).then((response) => {
+        return response;
+    })
+};
+export const doPutKenobiC2SUsingPublicRepo = (auth_key, kenobi_id) => {
+    return cy.fixture('api_Put_Kenobi_C2S_Public_Repo.json').then((myFixture) => {
+        cy.request({
+            method: 'PUT',
+            url: Cypress.env('baseUrl') + Cypress.env('CreateKenobiC2S') + kenobi_id + Cypress.env('CreateKenobiC2S1'),
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                'Authorization': 'Token ' + auth_key,
+            },
+            body: myFixture
+        }).then((response) => {
+            return response;
+        })
+    })
+};
+
+export const doPatchKenobiC2SUsingPublicRepo = (auth_key, kenobi_id) => {
+    return cy.fixture('api_Patch_Kenobi_C2S_Public_Repo.json').then((myFixture) => {
+        cy.request({
+            method: 'PATCH',
+            url: Cypress.env('baseUrl') + Cypress.env('CreateKenobiC2S') + kenobi_id + Cypress.env('CreateKenobiC2S1'),
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                'Authorization': 'Token ' + auth_key,
+            },
+            body: myFixture
+        }).then((response) => {
+            return response;
+        })
+    })
+};
+
+export const doDeleteKenobiC2SUsingPublicRepoById = (auth_key, kenobi_id) => {
+
+    return cy.request({
+        method: 'DELETE',
+        url: Cypress.env('baseUrl') + Cypress.env('CreateKenobiC2S') + kenobi_id + Cypress.env('CreateKenobiC2S1'),
+        headers: {
+            'Authorization': 'Token ' + auth_key
+        }
+    }).then((response) => {
+        return response;
+    })
+};
+
+
+
+
 
 

--- a/cypress/integration/api/tests/KenobiPageTest.js
+++ b/cypress/integration/api/tests/KenobiPageTest.js
@@ -1,8 +1,8 @@
-import { doCreateKenobiC2SUsingPrivateRepo, doGetKenobiC2SUsingPrivateRepoById, doPutKenobiC2SUsingPrivateRepo, doPatchKenobiC2SUsingPrivateRepo, doDeleteKenobiC2SUsingPrivateRepoById } from '../pages/KenobiPage.js';
+import { doCreateKenobiC2SUsingPrivateRepo, doGetKenobiC2SUsingPrivateRepoById, doPutKenobiC2SUsingPrivateRepo, doPatchKenobiC2SUsingPrivateRepo, doDeleteKenobiC2SUsingPrivateRepoById, doCreateKenobiC2SUsingPubliceRepo, doGetKenobiC2SUsingPublicRepoById, doPutKenobiC2SUsingPublicRepo, doPatchKenobiC2SUsingPublicRepo, doDeleteKenobiC2SUsingPublicRepoById } from '../pages/KenobiPage.js';
 import { doC2SLogin } from '../pages/loginPage.js';
 
 
-let authKey, C2SKenobi_id;
+let authKey, C2SKenobi_id,C2SKenobi_idPUB;
 
 describe("Kenobi Test Flow", () => {
 
@@ -41,6 +41,41 @@ describe("Kenobi Test Flow", () => {
     it('Delete C2S Kenobi by ID using Private Repo', () => {
         doDeleteKenobiC2SUsingPrivateRepoById(authKey, C2SKenobi_id).then((response) => {
             cy.log("Delete C2S Kenobi by ID using Private Repo Response", response.body)
+            expect(response.status).to.eq(204)
+        })
+    })
+
+    it('Create C2S Kenobi using Public Repo', () => {
+        doCreateKenobiC2SUsingPubliceRepo(authKey).then((response) => {
+            C2SKenobi_idPUB = response.body.id;
+            cy.log("Create C2S Kenobi using Public Repo Response", response.body)
+            expect(response.status).to.eq(201)
+        })
+    })
+
+    it('Get C2S Kenobi by ID using Public Repo', () => {
+        doGetKenobiC2SUsingPublicRepoById(authKey, C2SKenobi_idPUB).then((response) => {
+            cy.log("Get C2S Kenobi by ID using Public Repo Response", response.body)
+            expect(response.status).to.eq(200)
+        })
+    })
+
+    it('PUT C2S Kenobi by ID using Public Repo', () => {
+        doPutKenobiC2SUsingPublicRepo(authKey, C2SKenobi_idPUB).then((response) => {
+            cy.log("PUT C2S Kenobi by ID using Public Repo Response", response.body)
+            expect(response.status).to.eq(200)
+        })
+    })
+
+    it('PATCH C2S Kenobi by ID using Public Repo', () => {
+        doPatchKenobiC2SUsingPublicRepo(authKey, C2SKenobi_idPUB).then((response) => {
+            cy.log("PATCH C2S Kenobi by ID using Public Repo Response", response.body)
+            expect(response.status).to.eq(200)
+        })
+    })
+    it('Delete C2S Kenobi by ID using Public Repo', () => {
+        doDeleteKenobiC2SUsingPublicRepoById(authKey, C2SKenobi_idPUB).then((response) => {
+            cy.log("Delete C2S Kenobi by ID using Public Repo Response", response.body)
             expect(response.status).to.eq(204)
         })
     })


### PR DESCRIPTION
I have successfully automated the following five Kenobi-related APIs (for public repositories):
Create Kenobi using a public repository
Retrieve Kenobi by ID using a public repository
Update (PUT) Kenobi by ID using a public repository
Partially update (PATCH) Kenobi by ID using a public repository
Delete Kenobi by ID using a public repository

Artifact -

<img width="258" height="287" alt="image" src="https://github.com/user-attachments/assets/b5813013-c41e-4bc5-a0d5-bb095eff5b14" />
